### PR TITLE
global unsafe mode, fix several issues with unsafe handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ explains how to use `database/sql` along with sqlx.
 
 ## Changes compared to the original sqlx
 
+* Improved "unsafe" mode at the DB level. "Unsafe" isn't all that
+  unsafe, it really is just an additional check when scanning rows. If
+  there's a column in the row result that can't be mapped to the
+  struct, sqlx will return a "missing destination name" error. A new
+  WithUnsafe option for Connect and Open allows you to turn this off.
+
 1.6.0:
 
 * Set Go version to 1.23.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,18 @@
+min_version = "2024.9.5"
+
+[env]
+PROJECT_NAME = "sqlx"
+SQLX_MYSQL_DSN = "root:password@tcp(127.0.0.1:3306)/test"
+SQLX_POSTGRES_DSN = "user=user password=password dbname=postgres host=localhost sslmode=disable"
+
+[tools]
+"go" = { version = "1.23.8" }
+"go:honnef.co/go/tools/cmd/staticcheck" = { version = "v0.6.1" }
+"go:golang.org/x/vuln/cmd/govulncheck" = { version = "v1.1.4" }
+"go:golang.org/x/tools/cmd/goimports" = { version = "v0.20.0" }
+
+[tasks]
+test = "go test ./..."
+vet = "go vet ./..."
+static = "staticcheck -checks=all ./..."
+vuln = "govulncheck ./..."

--- a/named.go
+++ b/named.go
@@ -92,7 +92,7 @@ func (n *GenericNamedStmt[T]) Queryx(arg interface{}) (*Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Rows{Rows: r, Mapper: n.Stmt.Mapper, unsafe: isUnsafe(n)}, err
+	return &Rows{Rows: r, Mapper: n.Stmt.Mapper, options: n.Stmt.options}, err
 }
 
 // QueryRowx this NamedStmt.  Because of limitations with QueryRow, this is
@@ -173,18 +173,23 @@ func (n *GenericNamedStmt[T]) Prepare(ndb Queryable) *GenericNamedStmt[T] {
 		Params:      n.Params,
 		QueryString: n.QueryString,
 		Stmt: &GenericStmt[T]{
-			Stmt:   tx.Stmt(n.Stmt.Stmt),
-			unsafe: n.Stmt.unsafe,
-			Mapper: n.Stmt.Mapper,
+			Stmt:    tx.Stmt(n.Stmt.Stmt),
+			options: n.Stmt.options,
+			Mapper:  n.Stmt.Mapper,
 		},
 	}
 }
 
 // Unsafe creates an unsafe version of the GenericNamedStmt
 func (n *GenericNamedStmt[T]) Unsafe() *GenericNamedStmt[T] {
-	r := &GenericNamedStmt[T]{Params: n.Params, Stmt: n.Stmt, QueryString: n.QueryString}
-	r.Stmt.unsafe = true
+	stmt := n.Stmt.Unsafe()
+	r := &GenericNamedStmt[T]{Params: n.Params, Stmt: stmt, QueryString: n.QueryString}
 	return r
+}
+
+// getOptions work around type assertions with generics
+func (n *GenericNamedStmt[T]) getOptions() *dbOptions {
+	return n.Stmt.options
 }
 
 // A union interface of preparer and binder, required to be able to prepare

--- a/named_context.go
+++ b/named_context.go
@@ -84,7 +84,7 @@ func (n *GenericNamedStmt[T]) QueryxContext(ctx context.Context, arg interface{}
 	if err != nil {
 		return nil, err
 	}
-	return &Rows{Rows: r, Mapper: n.Stmt.Mapper, unsafe: isUnsafe(n)}, err
+	return &Rows{Rows: r, Mapper: n.Stmt.Mapper, options: n.Stmt.options}, err
 }
 
 // QueryRowxContext this NamedStmt.  Because of limitations with QueryRow, this is

--- a/sqlx.go
+++ b/sqlx.go
@@ -312,18 +312,18 @@ type DB struct {
 
 // NewDb returns a new sqlx DB wrapper for a pre-existing *sql.DB. The
 // driverName of the original database is required for named query support.
-// 
+//
 // This function now accepts functional options as variadic arguments to configure
 // the database instance. Functional options are functions that modify the internal
 // dbOptions struct. For example:
 //
-//     db := sqlx.NewDb(existingDB, "mysql", sqlx.WithUnsafe())
+//	db := sqlx.NewDb(existingDB, "mysql", sqlx.WithUnsafe())
 //
 // The above example enables unsafe mode, which allows sqlx to continue despite
 // scan issues like missing fields. You can also use WithSetUnsafe to explicitly
 // set the unsafe mode:
 //
-//     db := sqlx.NewDb(existingDB, "mysql", sqlx.WithSetUnsafe(true))
+//	db := sqlx.NewDb(existingDB, "mysql", sqlx.WithSetUnsafe(true))
 //
 // You can pass multiple functional options to configure other aspects of the
 // database as needed.

--- a/sqlx.go
+++ b/sqlx.go
@@ -113,41 +113,38 @@ type Preparer interface {
 	Prepare(query string) (*sql.Stmt, error)
 }
 
-// determine if any of our extensions are unsafe
-func isUnsafe(i interface{}) bool {
+// work around for type assertion with generics
+type optionalContainer interface {
+	getOptions() *dbOptions
+}
+
+// getOptions get options for the interface
+func getOptions(i interface{}) *dbOptions {
 	switch v := i.(type) {
-	case Row:
-		return v.unsafe
-	case *Row:
-		return v.unsafe
-	case Rows:
-		return v.unsafe
-	case *Rows:
-		return v.unsafe
-	case NamedStmt:
-		return v.Stmt.unsafe
-	case *NamedStmt:
-		return v.Stmt.unsafe
-	case Stmt:
-		return v.unsafe
-	case *Stmt:
-		return v.unsafe
-	case qStmt[any]:
-		return v.Stmt.unsafe
-	case *qStmt[any]:
-		return v.Stmt.unsafe
 	case DB:
-		return v.unsafe
+		return v.options
 	case *DB:
-		return v.unsafe
+		return v.options
 	case Tx:
-		return v.unsafe
+		return v.options
 	case *Tx:
-		return v.unsafe
-	case sql.Rows, *sql.Rows:
-		return false
+		return v.options
+	case Conn:
+		return v.options
+	case *Conn:
+		return v.options
+	case *Row:
+		return v.options
+	case Row:
+		return v.options
+	case *Rows:
+		return v.options
+	case Rows:
+		return v.options
+	case optionalContainer:
+		return v.getOptions()
 	default:
-		return false
+		return &dbOptions{}
 	}
 }
 
@@ -174,10 +171,10 @@ var _valuerInterface = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
 // Row is a reimplementation of sql.Row in order to gain access to the underlying
 // sql.Rows.Columns() data, necessary for StructScan.
 type Row struct {
-	err    error
-	unsafe bool
-	rows   *sql.Rows
-	Mapper *reflectx.Mapper
+	err     error
+	options *dbOptions
+	rows    *sql.Rows
+	Mapper  *reflectx.Mapper
 }
 
 // Scan is a fixed implementation of sql.Row.Scan, which does not discard the
@@ -282,21 +279,47 @@ type Queryable interface {
 var _ Queryable = (*DB)(nil)
 var _ Queryable = (*Tx)(nil)
 
+type dbOptions struct {
+	unsafe bool
+}
+
+func (o *dbOptions) allowMissingFields() bool {
+	return o.unsafe
+}
+
+// WithUnsafe in unsafe mode sqlx will do its best to continue despite scan issues like missing fields
+func WithUnsafe() func(*dbOptions) {
+	return func(opts *dbOptions) {
+		opts.unsafe = true
+	}
+}
+
+// WithSetUnsafe in unsafe mode sqlx will do its best to continue despite scan issues like missing fields
+func WithSetUnsafe(v bool) func(*dbOptions) {
+	return func(opts *dbOptions) {
+		opts.unsafe = v
+	}
+}
+
 // DB is a wrapper around sql.DB which keeps track of the driverName upon Open,
 // used mostly to automatically bind named queries using the right bindvars.
 type DB struct {
 	*sql.DB
 	driverName string
-	unsafe     bool
 	Mapper     *reflectx.Mapper
+	options    *dbOptions
 }
 
 // NewDb returns a new sqlx DB wrapper for a pre-existing *sql.DB.  The
 // driverName of the original database is required for named query support.
 //
 //lint:ignore ST1003 changing this would break the package interface.
-func NewDb(db *sql.DB, driverName string) *DB {
-	return &DB{DB: db, driverName: driverName, Mapper: mapper()}
+func NewDb(db *sql.DB, driverName string, args ...func(*dbOptions)) *DB {
+	opts := &dbOptions{}
+	for _, arg := range args {
+		arg(opts)
+	}
+	return &DB{DB: db, driverName: driverName, Mapper: mapper(), options: opts}
 }
 
 // DriverName returns the driverName passed to the Open function for this DB.
@@ -305,17 +328,21 @@ func (db *DB) DriverName() string {
 }
 
 // Open is the same as sql.Open, but returns an *sqlx.DB instead.
-func Open(driverName, dataSourceName string) (*DB, error) {
+func Open(driverName, dataSourceName string, args ...func(*dbOptions)) (*DB, error) {
+	opts := &dbOptions{}
+	for _, arg := range args {
+		arg(opts)
+	}
 	db, err := sql.Open(driverName, dataSourceName)
 	if err != nil {
 		return nil, err
 	}
-	return &DB{DB: db, driverName: driverName, Mapper: mapper()}, err
+	return &DB{DB: db, driverName: driverName, Mapper: mapper(), options: opts}, err
 }
 
 // MustOpen is the same as sql.Open, but returns an *sqlx.DB instead and panics on error.
-func MustOpen(driverName, dataSourceName string) *DB {
-	db, err := Open(driverName, dataSourceName)
+func MustOpen(driverName, dataSourceName string, args ...func(*dbOptions)) *DB {
+	db, err := Open(driverName, dataSourceName, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -338,7 +365,9 @@ func (db *DB) Rebind(query string) string {
 // sqlx.Stmt and sqlx.Tx which are created from this DB will inherit its
 // safety behavior.
 func (db *DB) Unsafe() *DB {
-	return &DB{DB: db.DB, driverName: db.driverName, unsafe: true, Mapper: db.Mapper}
+	opts := *db.options
+	opts.unsafe = true
+	return &DB{DB: db.DB, driverName: db.driverName, Mapper: db.Mapper, options: &opts}
 }
 
 // BindNamed binds a query using the DB driver's bindvar type.
@@ -387,7 +416,7 @@ func (db *DB) Beginx() (*Tx, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Tx{Tx: tx, driverName: db.driverName, unsafe: db.unsafe, Mapper: db.Mapper}, err
+	return &Tx{Tx: tx, driverName: db.driverName, options: db.options, Mapper: db.Mapper}, err
 }
 
 // Queryx queries the database and returns an *sqlx.Rows.
@@ -397,14 +426,14 @@ func (db *DB) Queryx(query string, args ...interface{}) (*Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Rows{Rows: r, unsafe: db.unsafe, Mapper: db.Mapper}, err
+	return &Rows{Rows: r, options: db.options, Mapper: db.Mapper}, err
 }
 
 // QueryRowx queries the database and returns an *sqlx.Row.
 // Any placeholder parameters are replaced with supplied args.
 func (db *DB) QueryRowx(query string, args ...interface{}) *Row {
 	rows, err := db.DB.Query(query, args...)
-	return &Row{rows: rows, err: err, unsafe: db.unsafe, Mapper: db.Mapper}
+	return &Row{rows: rows, err: err, options: db.options, Mapper: db.Mapper}
 }
 
 // MustExec (panic) runs MustExec using this database.
@@ -427,7 +456,7 @@ func (db *DB) PrepareNamed(query string) (*NamedStmt, error) {
 type Conn struct {
 	*sql.Conn
 	driverName string
-	unsafe     bool
+	options    *dbOptions
 	Mapper     *reflectx.Mapper
 }
 
@@ -435,7 +464,7 @@ type Conn struct {
 type Tx struct {
 	*sql.Tx
 	driverName string
-	unsafe     bool
+	options    *dbOptions
 	Mapper     *reflectx.Mapper
 }
 
@@ -452,7 +481,9 @@ func (tx *Tx) Rebind(query string) string {
 // Unsafe returns a version of Tx which will silently succeed to scan when
 // columns in the SQL result have no fields in the destination struct.
 func (tx *Tx) Unsafe() *Tx {
-	return &Tx{Tx: tx.Tx, driverName: tx.driverName, unsafe: true, Mapper: tx.Mapper}
+	opts := *tx.options
+	opts.unsafe = true
+	return &Tx{Tx: tx.Tx, driverName: tx.driverName, options: &opts, Mapper: tx.Mapper}
 }
 
 // BindNamed binds a query within a transaction's bindvar type.
@@ -485,14 +516,14 @@ func (tx *Tx) Queryx(query string, args ...interface{}) (*Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Rows{Rows: r, unsafe: tx.unsafe, Mapper: tx.Mapper}, err
+	return &Rows{Rows: r, options: tx.options, Mapper: tx.Mapper}, err
 }
 
 // QueryRowx within a transaction.
 // Any placeholder parameters are replaced with supplied args.
 func (tx *Tx) QueryRowx(query string, args ...interface{}) *Row {
 	rows, err := tx.Tx.Query(query, args...)
-	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
+	return &Row{rows: rows, err: err, options: tx.options, Mapper: tx.Mapper}
 }
 
 // Get within a transaction.
@@ -527,7 +558,7 @@ func (tx *Tx) Stmtx(stmt interface{}) *GenericStmt[any] {
 	default:
 		panic(fmt.Sprintf("non-statement type %v passed to Stmtx", reflect.ValueOf(stmt).Type()))
 	}
-	return &GenericStmt[any]{Stmt: tx.Stmt(s), Mapper: tx.Mapper}
+	return &GenericStmt[any]{Stmt: tx.Stmt(s), Mapper: tx.Mapper, options: tx.options}
 }
 
 // NamedStmt returns a version of the prepared statement which runs within a transaction.
@@ -547,8 +578,8 @@ func (tx *Tx) PrepareNamed(query string) (*NamedStmt, error) {
 // GenericStmt is an sqlx wrapper around sql.Stmt with extra functionality
 type GenericStmt[T any] struct {
 	*sql.Stmt
-	unsafe bool
-	Mapper *reflectx.Mapper
+	options *dbOptions
+	Mapper  *reflectx.Mapper
 }
 
 type Stmt = GenericStmt[any]
@@ -556,7 +587,9 @@ type Stmt = GenericStmt[any]
 // Unsafe returns a version of Stmt which will silently succeed to scan when
 // columns in the SQL result have no fields in the destination struct.
 func (s *GenericStmt[T]) Unsafe() *GenericStmt[T] {
-	return &GenericStmt[T]{Stmt: s.Stmt, unsafe: true, Mapper: s.Mapper}
+	opts := *s.options
+	opts.unsafe = true
+	return &GenericStmt[T]{Stmt: s.Stmt, options: &opts, Mapper: s.Mapper}
 }
 
 // Select using the prepared statement.
@@ -641,12 +674,22 @@ func (s *GenericStmt[T]) Prepare(ndb Queryable) *GenericStmt[T] {
 		// not needed
 		return s
 	}
-	return &GenericStmt[T]{Stmt: tx.Stmt(s.Stmt), unsafe: s.unsafe, Mapper: s.Mapper}
+	return &GenericStmt[T]{Stmt: tx.Stmt(s.Stmt), options: s.options, Mapper: s.Mapper}
+}
+
+// getOptions work around type assertions with generics
+func (n *GenericStmt[T]) getOptions() *dbOptions {
+	return n.options
 }
 
 // qStmt is an unexposed wrapper which lets you use a Stmt as a Queryer & Execer by
 // implementing those interfaces and ignoring the `query` argument.
 type qStmt[T any] struct{ Stmt *GenericStmt[T] }
+
+// getOptions work around type assertions with generics
+func (q *qStmt[T]) getOptions() *dbOptions {
+	return q.Stmt.options
+}
 
 func (q *qStmt[T]) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	return q.Stmt.Query(args...)
@@ -657,12 +700,12 @@ func (q *qStmt[T]) Queryx(query string, args ...interface{}) (*Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Rows{Rows: r, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}, err
+	return &Rows{Rows: r, options: q.Stmt.options, Mapper: q.Stmt.Mapper}, err
 }
 
 func (q *qStmt[T]) QueryRowx(query string, args ...interface{}) *Row {
 	rows, err := q.Stmt.Query(args...)
-	return &Row{rows: rows, err: err, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}
+	return &Row{rows: rows, err: err, options: q.Stmt.options, Mapper: q.Stmt.Mapper}
 }
 
 func (q *qStmt[T]) Exec(query string, args ...interface{}) (sql.Result, error) {
@@ -673,8 +716,8 @@ func (q *qStmt[T]) Exec(query string, args ...interface{}) (sql.Result, error) {
 // during a looped StructScan
 type Rows struct {
 	*sql.Rows
-	unsafe bool
-	Mapper *reflectx.Mapper
+	options *dbOptions
+	Mapper  *reflectx.Mapper
 	// these fields cache memory use for a rows during iteration w/ structScan
 	started bool
 	fields  [][]int
@@ -713,9 +756,11 @@ func (r *Rows) StructScan(dest interface{}) error {
 		m := r.Mapper
 
 		r.fields = m.TraversalsByName(v.Type(), columns)
-		// if we are not unsafe and are missing fields, return an error
-		if f, err := missingFields(r.fields); err != nil && !r.unsafe {
-			return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+		if !getOptions(r).allowMissingFields() {
+			// if we are not unsafe and are missing fields, return an error
+			if f, err := missingFields(r.fields); err != nil {
+				return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+			}
 		}
 		r.values = make([]interface{}, len(columns))
 		r.started = true
@@ -761,8 +806,8 @@ func AllRows[T any](rows *Rows) iter.Seq2[T, error] {
 }
 
 // Connect to a database and verify with a ping.
-func Connect(driverName, dataSourceName string) (*DB, error) {
-	db, err := Open(driverName, dataSourceName)
+func Connect(driverName, dataSourceName string, args ...func(*dbOptions)) (*DB, error) {
+	db, err := Open(driverName, dataSourceName, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -775,8 +820,8 @@ func Connect(driverName, dataSourceName string) (*DB, error) {
 }
 
 // MustConnect connects to a database and panics on error.
-func MustConnect(driverName, dataSourceName string) *DB {
-	db, err := Connect(driverName, dataSourceName)
+func MustConnect(driverName, dataSourceName string, args ...func(*dbOptions)) *DB {
+	db, err := Connect(driverName, dataSourceName, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -789,7 +834,7 @@ func Preparex[T any](p Preparer, query string) (*GenericStmt[T], error) {
 	if err != nil {
 		return nil, err
 	}
-	return &GenericStmt[T]{Stmt: s, unsafe: isUnsafe(p), Mapper: mapperFor(p)}, err
+	return &GenericStmt[T]{Stmt: s, options: getOptions(p), Mapper: mapperFor(p)}, err
 }
 
 // preparexStmt returns a Stmt, a workaround for type aliases and generics until Go 1.24
@@ -798,7 +843,7 @@ func preparexStmt(p Preparer, query string) (*Stmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Stmt{Stmt: s, unsafe: isUnsafe(p), Mapper: mapperFor(p)}, err
+	return &Stmt{Stmt: s, options: getOptions(p), Mapper: mapperFor(p)}, err
 }
 
 // Select executes a query using the provided Queryer, and StructScans each row
@@ -930,9 +975,11 @@ func (r *Row) scanAny(dest interface{}, structOnly bool) error {
 	m := r.Mapper
 
 	fields := m.TraversalsByName(v.Type(), columns)
-	// if we are not unsafe and are missing fields, return an error
-	if f, err := missingFields(fields); err != nil && !r.unsafe {
-		return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+	if !getOptions(r).allowMissingFields() {
+		// if we are not unsafe and are missing fields, return an error
+		if f, err := missingFields(fields); err != nil {
+			return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+		}
 	}
 	values := make([]interface{}, len(columns))
 
@@ -1098,9 +1145,11 @@ func scanAll(rows rowsi, dest interface{}, structOnly bool) error {
 		}
 
 		fields := m.TraversalsByName(base, columns)
-		// if we are not unsafe and are missing fields, return an error
-		if f, err := missingFields(fields); err != nil && !isUnsafe(rows) {
-			return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+		if !getOptions(rows).allowMissingFields() {
+			// if we are not unsafe and are missing fields, return an error
+			if f, err := missingFields(fields); err != nil {
+				return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+			}
 		}
 		values = make([]interface{}, len(columns))
 

--- a/sqlx.go
+++ b/sqlx.go
@@ -310,8 +310,23 @@ type DB struct {
 	options    *dbOptions
 }
 
-// NewDb returns a new sqlx DB wrapper for a pre-existing *sql.DB.  The
+// NewDb returns a new sqlx DB wrapper for a pre-existing *sql.DB. The
 // driverName of the original database is required for named query support.
+// 
+// This function now accepts functional options as variadic arguments to configure
+// the database instance. Functional options are functions that modify the internal
+// dbOptions struct. For example:
+//
+//     db := sqlx.NewDb(existingDB, "mysql", sqlx.WithUnsafe())
+//
+// The above example enables unsafe mode, which allows sqlx to continue despite
+// scan issues like missing fields. You can also use WithSetUnsafe to explicitly
+// set the unsafe mode:
+//
+//     db := sqlx.NewDb(existingDB, "mysql", sqlx.WithSetUnsafe(true))
+//
+// You can pass multiple functional options to configure other aspects of the
+// database as needed.
 //
 //lint:ignore ST1003 changing this would break the package interface.
 func NewDb(db *sql.DB, driverName string, args ...func(*dbOptions)) *DB {

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -43,6 +43,9 @@ var TestMysql = true
 var sldb *DB
 var pgdb *DB
 var mysqldb *DB
+var pgdsn string
+var mydsn string
+var sqdsn string
 
 func init() {
 	ConnectAll()
@@ -51,9 +54,9 @@ func init() {
 func ConnectAll() {
 	var err error
 
-	pgdsn := os.Getenv("SQLX_POSTGRES_DSN")
-	mydsn := os.Getenv("SQLX_MYSQL_DSN")
-	sqdsn := os.Getenv("SQLX_SQLITE_DSN")
+	pgdsn = os.Getenv("SQLX_POSTGRES_DSN")
+	mydsn = os.Getenv("SQLX_MYSQL_DSN")
+	sqdsn = os.Getenv("SQLX_SQLITE_DSN")
 
 	TestPostgres = pgdsn != "skip"
 	TestMysql = mydsn != "skip"
@@ -261,6 +264,32 @@ func loadDefaultFixture(db *DB, t *testing.T) {
 	tx.Commit()
 }
 
+// tests the options on the DB struct
+func TestUnsafeDBOptions(t *testing.T) {
+	if TestPostgres {
+		tdb, err := Connect("postgres", pgdsn, WithUnsafe())
+		require.NoError(t, err)
+		assert.True(t, getOptions(tdb).allowMissingFields())
+		tdb, err = Connect("postgres", pgdsn, WithSetUnsafe(true))
+		require.NoError(t, err)
+		assert.True(t, getOptions(tdb).allowMissingFields())
+	} else if TestSqlite {
+		tdb, err := Connect("sqlite3", sqdsn, WithUnsafe())
+		require.NoError(t, err)
+		assert.True(t, getOptions(tdb).allowMissingFields())
+		tdb, err = Connect("sqlite3", sqdsn, WithSetUnsafe(true))
+		require.NoError(t, err)
+		assert.True(t, getOptions(tdb).allowMissingFields())
+	} else if TestMysql {
+		tdb, err := Connect("mysql", mydsn, WithUnsafe())
+		require.NoError(t, err)
+		assert.True(t, getOptions(tdb).allowMissingFields())
+		tdb, err = Connect("mysql", mydsn, WithUnsafe())
+		require.NoError(t, err)
+		assert.True(t, getOptions(tdb).allowMissingFields())
+	}
+}
+
 // Test a new backwards compatible feature, that missing scan destinations
 // will silently scan into sql.RawText rather than failing/panicing
 func TestMissingNames(t *testing.T) {
@@ -273,107 +302,146 @@ func TestMissingNames(t *testing.T) {
 			// AddedAt time.Time `db:"added_at"`
 		}
 
-		// test Select first
-		pps := []PersonPlus{}
-		// pps lacks added_at destination
-		err := db.Select(&pps, "SELECT * FROM person")
-		if err == nil {
-			t.Error("Expected missing name from Select to fail, but it did not.")
+		{
+			undb := db.Unsafe()
+			assert.False(t, getOptions(db).allowMissingFields(), "expected db to still be safe")
+			assert.True(t, getOptions(undb).allowMissingFields(), "expected db to still be unsafe after Unsafe()")
 		}
 
-		// test Get
-		pp := PersonPlus{}
-		err = db.Get(&pp, "SELECT * FROM person LIMIT 1")
-		if err == nil {
-			t.Error("Expected missing name Get to fail, but it did not.")
+		{
+			// test Select first
+			pps := []PersonPlus{}
+			// pps lacks added_at destination
+			err := db.Select(&pps, "SELECT * FROM person")
+			if err == nil {
+				t.Error("Expected missing name from Select to fail, but it did not.")
+			}
 		}
 
-		// test naked StructScan
-		pps = []PersonPlus{}
-		rows, err := db.Query("SELECT * FROM person LIMIT 1")
-		if err != nil {
-			t.Fatal(err)
-		}
-		rows.Next()
-		err = StructScan(rows, &pps)
-		if err == nil {
-			t.Error("Expected missing name in StructScan to fail, but it did not.")
-		}
-		rows.Close()
-
-		// now try various things with unsafe set.
-		db = db.Unsafe()
-		pps = []PersonPlus{}
-		err = db.Select(&pps, "SELECT * FROM person")
-		if err != nil {
-			t.Error(err)
+		{
+			// test Get
+			pp := PersonPlus{}
+			err := db.Get(&pp, "SELECT * FROM person LIMIT 1")
+			if err == nil {
+				t.Error("Expected missing name Get to fail, but it did not.")
+			}
 		}
 
-		// test Get
-		pp = PersonPlus{}
-		err = db.Get(&pp, "SELECT * FROM person LIMIT 1")
-		if err != nil {
-			t.Error(err)
+		{
+			// test naked StructScan
+			pps := []PersonPlus{}
+			rows, err := db.Query("SELECT * FROM person LIMIT 1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			rows.Next()
+			err = StructScan(rows, &pps)
+			if err == nil {
+				t.Error("Expected missing name in StructScan to fail, but it did not.")
+			}
+			rows.Close()
 		}
 
-		// test naked StructScan
-		pps = []PersonPlus{}
-		rowsx, err := db.Queryx("SELECT * FROM person LIMIT 1")
-		if err != nil {
-			t.Fatal(err)
-		}
-		rowsx.Next()
-		err = StructScan(rowsx, &pps)
-		if err != nil {
-			t.Error(err)
-		}
-		rowsx.Close()
-
-		// test Named stmt
-		if !isUnsafe(db) {
-			t.Error("Expected db to be unsafe, but it isn't")
-		}
-		nstmt, err := db.PrepareNamed(`SELECT * FROM person WHERE first_name != :name`)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// its internal stmt should be marked unsafe
-		if !nstmt.Stmt.unsafe {
-			t.Error("expected NamedStmt to be unsafe but its underlying stmt did not inherit safety")
-		}
-		pps = []PersonPlus{}
-		err = nstmt.Select(&pps, map[string]interface{}{"name": "Jason"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(pps) != 1 {
-			t.Errorf("Expected 1 person back, got %d", len(pps))
+		{
+			// now try various things with unsafe set.
+			db := db.Unsafe()
+			pps := []PersonPlus{}
+			err := db.Select(&pps, "SELECT * FROM person")
+			require.NoError(t, err)
 		}
 
-		// test it with a safe db
-		db.unsafe = false
-		if isUnsafe(db) {
-			t.Error("expected db to be safe but it isn't")
+		{
+			// test Get
+			db := db.Unsafe()
+			pp := PersonPlus{}
+			err := db.Get(&pp, "SELECT * FROM person LIMIT 1")
+			require.NoError(t, err)
 		}
-		nstmt, err = db.PrepareNamed(`SELECT * FROM person WHERE first_name != :name`)
-		if err != nil {
-			t.Fatal(err)
+
+		{
+			// test naked StructScan
+			db := db.Unsafe()
+			pps := []PersonPlus{}
+			rowsx, err := db.Queryx("SELECT * FROM person LIMIT 1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			rowsx.Next()
+			err = StructScan(rowsx, &pps)
+			if err != nil {
+				t.Error(err)
+			}
+			rowsx.Close()
 		}
-		// it should be safe
-		if isUnsafe(nstmt) {
-			t.Error("NamedStmt did not inherit safety")
+
+		{
+			// test Named stmt
+			db := db.Unsafe()
+			nstmt, err := db.PrepareNamed(`SELECT * FROM person WHERE first_name != :name`)
+			require.NoError(t, err)
+			// its internal stmt should be marked unsafe
+			if !getOptions(nstmt.Stmt).allowMissingFields() {
+				t.Error("expected NamedStmt to be unsafe but its underlying stmt did not inherit safety")
+			}
+			pps := []PersonPlus{}
+			err = nstmt.Select(&pps, map[string]interface{}{"name": "Jason"})
+			require.NoError(t, err)
+			if len(pps) != 1 {
+				t.Errorf("Expected 1 person back, got %d", len(pps))
+			}
 		}
-		nstmt.Unsafe()
-		if !isUnsafe(nstmt) {
-			t.Error("expected newly unsafed NamedStmt to be unsafe")
+
+		{
+			// test it with a safe db
+			nstmt, err := db.PrepareNamed(`SELECT * FROM person WHERE first_name != :name`)
+			require.NoError(t, err)
+			// it should be safe
+			if getOptions(nstmt).allowMissingFields() {
+				t.Error("NamedStmt did not inherit safety")
+			}
+			nstmt = nstmt.Unsafe()
+			if !getOptions(nstmt).allowMissingFields() {
+				t.Error("expected newly unsafed NamedStmt to be unsafe")
+			}
+			pps := []PersonPlus{}
+			err = nstmt.Select(&pps, map[string]interface{}{"name": "Jason"})
+			require.NoError(t, err)
+			if len(pps) != 1 {
+				t.Errorf("Expected 1 person back, got %d", len(pps))
+			}
 		}
-		pps = []PersonPlus{}
-		err = nstmt.Select(&pps, map[string]interface{}{"name": "Jason"})
-		if err != nil {
-			t.Fatal(err)
+
+		{
+			// generic version, stmt
+			db := db.Unsafe()
+			rebound := db.Rebind(`SELECT * FROM person WHERE first_name != ?`)
+			ps, err := Preparex[PersonPlus](db, rebound)
+			require.NoError(t, err)
+			// it should be unsafe
+			if !getOptions(ps).allowMissingFields() {
+				t.Error("NamedStmt did not inherit unsafe")
+			}
+			pps, err := ps.List("Jason")
+			require.NoError(t, err)
+			if len(pps) != 1 {
+				t.Errorf("Expected 1 person back, got %d", len(pps))
+			}
 		}
-		if len(pps) != 1 {
-			t.Errorf("Expected 1 person back, got %d", len(pps))
+
+		{
+			// generic version
+			db := db.Unsafe()
+			ps, err := PrepareNamed[PersonPlus](db, `SELECT * FROM person WHERE first_name != :name`)
+			require.NoError(t, err)
+			// it should be unsafe
+			if !getOptions(ps).allowMissingFields() {
+				t.Error("NamedStmt did not inherit unsafe")
+			}
+			pps, err := ps.List(map[string]interface{}{"name": "Jason"})
+			require.NoError(t, err)
+			if len(pps) != 1 {
+				t.Errorf("Expected 1 person back, got %d", len(pps))
+			}
 		}
 	})
 }


### PR DESCRIPTION
Like the original issue, we have had issues with some statements that `select *` from tables. This works fine until a migration adds a column and sqlx starts thrown errors. Our fix so far has been to generate sql with column names but that doesn't always work smoothly for more complicated queries.

Unsafe is a great validation tool for testing and dev but a new column that can't be scanned should not cause an outage. With this patch, we can turn on unsafe mode for production and sleep a little better at night. I considered the previous patch to add logging instead of unsafe and might add that as a future option, but for our setup the overhead of logging every statement might cause a performance degradation of its own.

This patch also adds an options struct so new config options won't have to also carefully make sure they are copied everywhere.

https://github.com/jmoiron/sqlx/issues/703

https://github.com/jmoiron/sqlx/pull/789
