### PR TITLE
remove old todo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.2]
+        go-version: [1.23.8, 1.24.4]
     services:
       postgres:
         image: postgres:17.4
@@ -59,14 +59,14 @@ jobs:
           chart: true
           amend: true
         if: |
-          matrix.go-version == '1.24.2'
+          matrix.go-version == '1.24.4'
         continue-on-error: true
 
   test-race:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.2]
+        go-version: [1.23.8, 1.24.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.2]
+        go-version: [1.23.8, 1.24.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.2]
+        go-version: [1.23.8, 1.24.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.4]
+        go-version: [1.23.10, 1.24.4]
     services:
       postgres:
         image: postgres:17.4
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.4]
+        go-version: [1.23.10, 1.24.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.4]
+        go-version: [1.23.10, 1.24.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.8, 1.24.4]
+        go-version: [1.23.10, 1.24.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/sqlx.go
+++ b/sqlx.go
@@ -185,19 +185,11 @@ func (r *Row) Scan(dest ...interface{}) error {
 		return r.err
 	}
 
-	// TODO(bradfitz): for now we need to defensively clone all
-	// []byte that the driver returned (not permitting
-	// *RawBytes in Rows.Scan), since we're about to close
+	// clone all []byte that the driver returned since we're about to close
 	// the Rows in our defer, when we return from this function.
 	// the contract with the driver.Next(...) interface is that it
 	// can return slices into read-only temporary memory that's
-	// only valid until the next Scan/Close.  But the TODO is that
-	// for a lot of drivers, this copy will be unnecessary.  We
-	// should provide an optional interface for drivers to
-	// implement to say, "don't worry, the []bytes that I return
-	// from Next will not be modified again." (for instance, if
-	// they were obtained from the network anyway) But for now we
-	// don't care.
+	// only valid until the next Scan/Close.
 	defer r.rows.Close()
 	for _, dp := range dest {
 		if _, ok := dp.(*sql.RawBytes); ok {


### PR DESCRIPTION
it seems the behavior has since been decided that the database driver owns the memory https://github.com/golang/go/commit/94280237f4863db90e442481c5cc4edfd13389a9