### PR TITLE
Optional nested structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ explains how to use `database/sql` along with sqlx.
 
 ## Changes compared to the original sqlx
 
+* Better scanning in the case of outer joins. If a struct contains a nested
+  struct pointer, it will no longer be a scan error.
+
 * Made complex joins easier to scan by using the position of the field
   to help map duplicate column names into structs. See the [joins
   example](./examples/joins/main.go).

--- a/convert.go
+++ b/convert.go
@@ -1,0 +1,8 @@
+package sqlx
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname convertAssign database/sql.convertAssign
+func convertAssign(dest, src interface{}) error

--- a/examples/generics/main.go
+++ b/examples/generics/main.go
@@ -15,7 +15,8 @@ import (
 // docker run --name sqlxpg -p 5444:5432 -e POSTGRES_PASSWORD=password -d docker.io/postgres:17.4
 
 const schema = `
-	CREATE TABLE IF NOT EXISTS person (
+	DROP TABLE IF EXISTS person;
+	CREATE TABLE person (
 	    id SERIAL PRIMARY KEY,
 		first_name text,
 		last_name text,
@@ -23,7 +24,8 @@ const schema = `
 	);
 	TRUNCATE TABLE person;
 	
-	CREATE TABLE IF NOT EXISTS place (
+	DROP TABLE IF EXISTS place;
+	CREATE TABLE place (
 		country text,
 		city text NULL,
 		telcode integer

--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -235,8 +235,7 @@ func FieldByIndexes(v reflect.Value, indexes []int) reflect.Value {
 		v = reflect.Indirect(v).Field(i)
 		// if this is a pointer and it's nil, allocate a new value and set it
 		if v.Kind() == reflect.Ptr && v.IsNil() {
-			alloc := reflect.New(Deref(v.Type()))
-			v.Set(alloc)
+			v.Set(reflect.New(v.Type().Elem()))
 		}
 		if v.Kind() == reflect.Map && v.IsNil() {
 			v.Set(reflect.MakeMap(v.Type()))

--- a/sqlx.go
+++ b/sqlx.go
@@ -1246,7 +1246,6 @@ func fieldsByTraversal(v reflect.Value, traversals [][]int, values []interface{}
 			// reflectx.FieldByIndexes initializes pointer fields, including pointers to nested structs.
 			// Use optDest to delay it until the first non-NULL value is scanned into a field of a nested struct.
 			// That way we can support LEFT JOINs with optional nested structs.
-			traversal := traversal
 			values[i] = optDest(func() interface{} {
 				return reflectx.FieldByIndexes(v, traversal).Addr().Interface()
 			})

--- a/sqlx_context_test.go
+++ b/sqlx_context_test.go
@@ -473,12 +473,17 @@ func TestNamedQueryContext(t *testing.T) {
 				"FIRST" text NULL,
 				last_name text NULL,
 				"EMAIL" text NULL
+			);
+			CREATE TABLE persondetails (
+				email text NULL,
+				notes text NULL
 			);`,
 		drop: `
 			drop table person;
 			drop table jsperson;
 			drop table place;
 			drop table placeperson;
+			drop table persondetails;
 			`,
 	}
 
@@ -677,6 +682,229 @@ func TestNamedQueryContext(t *testing.T) {
 			}
 			if pp2.Place.ID != pp.Place.ID {
 				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp2.Place.ID)
+			}
+		}
+
+		rows.Close()
+
+		type Owner struct {
+			Email     *string `db:"email"`
+			FirstName string  `db:"first_name"`
+			LastName  string  `db:"last_name"`
+		}
+
+		// Test optional nested structs with left join
+		type PlaceOwner struct {
+			Place Place  `db:"place"`
+			Owner *Owner `db:"owner"`
+		}
+
+		pl = Place{
+			Name: sql.NullString{String: "the-house", Valid: true},
+		}
+
+		q4 := `INSERT INTO place (id, name) VALUES (2, :name)`
+		_, err = db.NamedExecContext(ctx, q4, pl)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		id = 2
+		pp.Place.ID = id
+
+		q5 := `INSERT INTO placeperson (first_name, last_name, email, place_id) VALUES (:first_name, :last_name, :email, :place.id)`
+		_, err = db.NamedExecContext(ctx, q5, pp)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		pp3 := &PlaceOwner{}
+		rows, err = db.NamedQueryContext(ctx, `
+			SELECT
+				place.id AS "place.id",
+				place.name AS "place.name",
+				placeperson.first_name "owner.first_name",
+				placeperson.last_name "owner.last_name",
+				placeperson.email "owner.email"
+			FROM place
+			LEFT JOIN placeperson ON false -- null left join 
+			WHERE
+				place.id=:place.id`, pp)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(pp3)
+			if err != nil {
+				t.Error(err)
+			}
+			if pp3.Owner != nil {
+				t.Error("Expected `Owner` to be nil")
+			}
+			if pp3.Place.Name.String != "the-house" {
+				t.Error("Expected place name of `the-house`, got " + pp3.Place.Name.String)
+			}
+			if pp3.Place.ID != pp.Place.ID {
+				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp3.Place.ID)
+			}
+		}
+
+		rows.Close()
+
+		pp4 := &PlaceOwner{}
+		rows, err = db.NamedQueryContext(ctx, `
+			SELECT
+				place.id AS "place.id",
+				place.name AS "place.name",
+				placeperson.first_name "owner.first_name",
+				placeperson.last_name "owner.last_name",
+				placeperson.email "owner.email"
+			FROM place
+			LEFT JOIN placeperson ON placeperson.place_id = place.id
+			WHERE
+				place.id=:place.id`, pp)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(pp4)
+			if err != nil {
+				t.Error(err)
+			}
+			if pp4.Owner == nil {
+				t.Error("Expected `Owner` to not be nil")
+			}
+			if pp4.Owner.FirstName != "ben" {
+				t.Error("Expected first name of `ben`, got " + pp4.Owner.FirstName)
+			}
+			if pp4.Owner.LastName != "doe" {
+				t.Error("Expected first name of `doe`, got " + pp4.Owner.LastName)
+			}
+			if pp4.Place.Name.String != "the-house" {
+				t.Error("Expected place name of `the-house`, got " + pp4.Place.Name.String)
+			}
+			if pp4.Place.ID != pp.Place.ID {
+				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp4.Place.ID)
+			}
+		}
+
+		type Details struct {
+			Email string `db:"email"`
+			Notes string `db:"notes"`
+		}
+
+		type OwnerDetails struct {
+			Email     *string  `db:"email"`
+			FirstName string   `db:"first_name"`
+			LastName  string   `db:"last_name"`
+			Details   *Details `db:"details"`
+		}
+
+		type PlaceOwnerDetails struct {
+			Place Place         `db:"place"`
+			Owner *OwnerDetails `db:"owner"`
+		}
+
+		pp5 := &PlaceOwnerDetails{}
+		rows, err = db.NamedQueryContext(ctx, `
+			SELECT
+				place.id AS "place.id",
+				place.name AS "place.name",
+				placeperson.first_name "owner.first_name",
+				placeperson.last_name "owner.last_name",
+				placeperson.email "owner.email",
+				persondetails.email "owner.details.email",
+				persondetails.notes "owner.details.notes"
+			FROM place
+			LEFT JOIN placeperson ON placeperson.place_id = place.id
+			LEFT JOIN persondetails ON false
+			WHERE
+				place.id=:place.id`, pp)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(pp5)
+			if err != nil {
+				t.Error(err)
+			}
+			if pp5.Owner == nil {
+				t.Error("Expected `Owner`, to not be nil")
+			}
+			if pp5.Owner.FirstName != "ben" {
+				t.Error("Expected first name of `ben`, got " + pp5.Owner.FirstName)
+			}
+			if pp5.Owner.LastName != "doe" {
+				t.Error("Expected first name of `doe`, got " + pp5.Owner.LastName)
+			}
+			if pp5.Place.Name.String != "the-house" {
+				t.Error("Expected place name of `the-house`, got " + pp5.Place.Name.String)
+			}
+			if pp5.Place.ID != pp.Place.ID {
+				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp5.Place.ID)
+			}
+			if pp5.Owner.Details != nil {
+				t.Error("Expected `Details` to be nil")
+			}
+		}
+
+		details := Details{
+			Email: pp.Email.String,
+			Notes: "this is a test person",
+		}
+
+		q6 := `INSERT INTO persondetails (email, notes) VALUES (:email, :notes)`
+		_, err = db.NamedExecContext(ctx, q6, details)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		pp6 := &PlaceOwnerDetails{}
+		rows, err = db.NamedQueryContext(ctx, `
+			SELECT
+				place.id AS "place.id",
+				place.name AS "place.name",
+				placeperson.first_name "owner.first_name",
+				placeperson.last_name "owner.last_name",
+				placeperson.email "owner.email",
+				persondetails.email "owner.details.email",
+				persondetails.notes "owner.details.notes"
+			FROM place
+			LEFT JOIN placeperson ON placeperson.place_id = place.id
+			LEFT JOIN persondetails ON persondetails.email = placeperson.email
+			WHERE
+				place.id=:place.id`, pp)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(pp6)
+			if err != nil {
+				t.Error(err)
+			}
+			if pp6.Owner == nil {
+				t.Error("Expected `Owner` to not be nil")
+			}
+			if pp6.Owner.FirstName != "ben" {
+				t.Error("Expected first name of `ben`, got " + pp6.Owner.FirstName)
+			}
+			if pp6.Owner.LastName != "doe" {
+				t.Error("Expected first name of `doe`, got " + pp6.Owner.LastName)
+			}
+			if pp6.Place.Name.String != "the-house" {
+				t.Error("Expected place name of `the-house`, got " + pp6.Place.Name.String)
+			}
+			if pp6.Place.ID != pp.Place.ID {
+				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp6.Place.ID)
+			}
+			if pp6.Owner.Details == nil {
+				t.Error("Expected `Details` to not be nil")
+			}
+			if pp6.Owner.Details.Email != details.Email {
+				t.Errorf("Expected details email of %v, got %v", details.Email, pp6.Owner.Details.Email)
+			}
+			if pp6.Owner.Details.Notes != details.Notes {
+				t.Errorf("Expected details notes of %v, got %v", details.Notes, pp6.Owner.Details.Notes)
 			}
 		}
 	})

--- a/sqlx_context_test.go
+++ b/sqlx_context_test.go
@@ -500,28 +500,28 @@ func TestNamedQueryContext(t *testing.T) {
 			Email:     sql.NullString{String: "ben@doe.com", Valid: true},
 		}
 
-		q1 := `INSERT INTO person (first_name, last_name, email) VALUES (:first_name, :last_name, :email)`
-		_, err := db.NamedExecContext(ctx, q1, p)
-		if err != nil {
-			log.Fatal(err)
-		}
+		_, err := db.NamedExecContext(ctx, `INSERT INTO person (first_name, last_name, email) VALUES (:first_name, :last_name, :email)`, p)
+		require.NoError(t, err)
 
-		p2 := &Person{}
-		rows, err := db.NamedQueryContext(ctx, "SELECT * FROM person WHERE first_name=:first_name", p)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for rows.Next() {
-			err = rows.StructScan(p2)
+		{
+			p2 := &Person{}
+			rows, err := db.NamedQueryContext(ctx, "SELECT * FROM person WHERE first_name=:first_name", p)
 			if err != nil {
-				t.Error(err)
+				log.Fatal(err)
 			}
-			if p2.FirstName.String != "ben" {
-				t.Error("Expected first name of `ben`, got " + p2.FirstName.String)
+			for rows.Next() {
+				err = rows.StructScan(p2)
+				if err != nil {
+					t.Error(err)
+				}
+				if p2.FirstName.String != "ben" {
+					t.Error("Expected first name of `ben`, got " + p2.FirstName.String)
+				}
+				if p2.LastName.String != "doe" {
+					t.Error("Expected first name of `doe`, got " + p2.LastName.String)
+				}
 			}
-			if p2.LastName.String != "doe" {
-				t.Error("Expected first name of `doe`, got " + p2.LastName.String)
-			}
+			rows.Close()
 		}
 
 		// these are tests for #73;  they verify that named queries work if you've
@@ -553,8 +553,7 @@ func TestNamedQueryContext(t *testing.T) {
 			return s
 		}
 
-		q1 = `INSERT INTO jsperson ("FIRST", last_name, "EMAIL") VALUES (:FIRST, :last_name, :EMAIL)`
-		_, err = db.NamedExecContext(ctx, pdb(q1, db), jp)
+		_, err = db.NamedExecContext(ctx, pdb(`INSERT INTO jsperson ("FIRST", last_name, "EMAIL") VALUES (:FIRST, :last_name, :EMAIL)`, db), jp)
 		if err != nil {
 			t.Fatal(err, db.DriverName())
 		}
@@ -586,16 +585,13 @@ func TestNamedQueryContext(t *testing.T) {
 				last_name=:last_name AND
 				"EMAIL"=:EMAIL
 		`, db))
+		require.NoError(t, err)
 
-		if err != nil {
-			t.Fatal(err)
-		}
-		rows, err = ns.QueryxContext(ctx, jp)
-		if err != nil {
-			t.Fatal(err)
-		}
+		rows, err := ns.QueryxContext(ctx, jp)
+		require.NoError(t, err)
 
 		check(t, rows)
+		rows.Close()
 
 		// Check exactly the same thing, but with db.NamedQuery, which does not go
 		// through the PrepareNamed/NamedStmt path.
@@ -606,11 +602,10 @@ func TestNamedQueryContext(t *testing.T) {
 				last_name=:last_name AND
 				"EMAIL"=:EMAIL
 		`, db), jp)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		check(t, rows)
+		rows.Close()
 
 		db.Mapper = old
 
@@ -630,29 +625,23 @@ func TestNamedQueryContext(t *testing.T) {
 			Name: sql.NullString{String: "myplace", Valid: true},
 		}
 
-		pp := PlacePerson{
+		benDoe := PlacePerson{
 			FirstName: sql.NullString{String: "ben", Valid: true},
 			LastName:  sql.NullString{String: "doe", Valid: true},
 			Email:     sql.NullString{String: "ben@doe.com", Valid: true},
 		}
 
-		q2 := `INSERT INTO place (id, name) VALUES (1, :name)`
-		_, err = db.NamedExecContext(ctx, q2, pl)
-		if err != nil {
-			log.Fatal(err)
-		}
+		_, err = db.NamedExecContext(ctx, `INSERT INTO place (id, name) VALUES (1, :name)`, pl)
+		require.NoError(t, err)
 
 		id := 1
-		pp.Place.ID = id
+		benDoe.Place.ID = id
 
-		q3 := `INSERT INTO placeperson (first_name, last_name, email, place_id) VALUES (:first_name, :last_name, :email, :place.id)`
-		_, err = db.NamedExecContext(ctx, q3, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
+		_, err = db.NamedExecContext(ctx, `INSERT INTO placeperson (first_name, last_name, email, place_id) VALUES (:first_name, :last_name, :email, :place.id)`, benDoe)
+		require.NoError(t, err)
 
-		pp2 := &PlacePerson{}
-		rows, err = db.NamedQueryContext(ctx, `
+		{
+			rows, err = db.NamedQueryContext(ctx, `
 			SELECT
 				first_name,
 				last_name,
@@ -662,30 +651,17 @@ func TestNamedQueryContext(t *testing.T) {
 			FROM placeperson
 			INNER JOIN place ON place.id = placeperson.place_id
 			WHERE
-				place.id=:place.id`, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for rows.Next() {
-			err = rows.StructScan(pp2)
-			if err != nil {
-				t.Error(err)
-			}
-			if pp2.FirstName.String != "ben" {
-				t.Error("Expected first name of `ben`, got " + pp2.FirstName.String)
-			}
-			if pp2.LastName.String != "doe" {
-				t.Error("Expected first name of `doe`, got " + pp2.LastName.String)
-			}
-			if pp2.Place.Name.String != "myplace" {
-				t.Error("Expected place name of `myplace`, got " + pp2.Place.Name.String)
-			}
-			if pp2.Place.ID != pp.Place.ID {
-				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp2.Place.ID)
-			}
-		}
+				place.id = :place.id`, benDoe)
+			require.NoError(t, err)
 
-		rows.Close()
+			for pp2, err := range AllRows[PlacePerson](rows) {
+				require.NoError(t, err)
+				assert.Equal(t, benDoe.FirstName.String, pp2.FirstName.String)
+				assert.Equal(t, benDoe.LastName.String, pp2.LastName.String)
+				assert.Equal(t, benDoe.Email.String, pp2.Email.String)
+				assert.Equal(t, benDoe.Place.ID, pp2.Place.ID)
+			}
+		}
 
 		type Owner struct {
 			Email     *string `db:"email"`
@@ -703,88 +679,58 @@ func TestNamedQueryContext(t *testing.T) {
 			Name: sql.NullString{String: "the-house", Valid: true},
 		}
 
-		q4 := `INSERT INTO place (id, name) VALUES (2, :name)`
-		_, err = db.NamedExecContext(ctx, q4, pl)
-		if err != nil {
-			log.Fatal(err)
-		}
+		_, err = db.NamedExecContext(ctx, `INSERT INTO place (id, name) VALUES (2, :name)`, pl)
+		require.NoError(t, err)
 
 		id = 2
-		pp.Place.ID = id
+		benDoe.Place.ID = id
 
-		q5 := `INSERT INTO placeperson (first_name, last_name, email, place_id) VALUES (:first_name, :last_name, :email, :place.id)`
-		_, err = db.NamedExecContext(ctx, q5, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
+		_, err = db.NamedExecContext(ctx, `INSERT INTO placeperson (first_name, last_name, email, place_id) VALUES (:first_name, :last_name, :email, :place.id)`, benDoe)
+		require.NoError(t, err)
 
-		pp3 := &PlaceOwner{}
-		rows, err = db.NamedQueryContext(ctx, `
+		{
+			rows, err = db.NamedQueryContext(ctx, `
 			SELECT
-				place.id AS "place.id",
-				place.name AS "place.name",
-				placeperson.first_name "owner.first_name",
-				placeperson.last_name "owner.last_name",
-				placeperson.email "owner.email"
+				place.id,
+				place.name,
+				placeperson.first_name,
+				placeperson.last_name,
+				placeperson.email
 			FROM place
 			LEFT JOIN placeperson ON false -- null left join 
 			WHERE
-				place.id=:place.id`, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for rows.Next() {
-			err = rows.StructScan(pp3)
-			if err != nil {
-				t.Error(err)
-			}
-			if pp3.Owner != nil {
-				t.Error("Expected `Owner` to be nil")
-			}
-			if pp3.Place.Name.String != "the-house" {
-				t.Error("Expected place name of `the-house`, got " + pp3.Place.Name.String)
-			}
-			if pp3.Place.ID != pp.Place.ID {
-				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp3.Place.ID)
+				place.id = :place.id`, benDoe)
+			require.NoError(t, err)
+
+			for pp3, err := range AllRows[PlaceOwner](rows) {
+				require.NoError(t, err)
+				assert.Nil(t, pp3.Owner, "Expected `Owner` to be nil")
+				assert.Equal(t, "the-house", pp3.Place.Name.String)
+				assert.Equal(t, benDoe.Place.ID, pp3.Place.ID)
 			}
 		}
 
-		rows.Close()
-
-		pp4 := &PlaceOwner{}
-		rows, err = db.NamedQueryContext(ctx, `
+		{
+			rows, err = db.NamedQueryContext(ctx, `
 			SELECT
-				place.id AS "place.id",
-				place.name AS "place.name",
-				placeperson.first_name "owner.first_name",
-				placeperson.last_name "owner.last_name",
-				placeperson.email "owner.email"
+				place.id,
+				place.name,
+				placeperson.first_name,
+				placeperson.last_name,
+				placeperson.email
 			FROM place
 			LEFT JOIN placeperson ON placeperson.place_id = place.id
 			WHERE
-				place.id=:place.id`, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for rows.Next() {
-			err = rows.StructScan(pp4)
-			if err != nil {
-				t.Error(err)
-			}
-			if pp4.Owner == nil {
-				t.Error("Expected `Owner` to not be nil")
-			}
-			if pp4.Owner.FirstName != "ben" {
-				t.Error("Expected first name of `ben`, got " + pp4.Owner.FirstName)
-			}
-			if pp4.Owner.LastName != "doe" {
-				t.Error("Expected first name of `doe`, got " + pp4.Owner.LastName)
-			}
-			if pp4.Place.Name.String != "the-house" {
-				t.Error("Expected place name of `the-house`, got " + pp4.Place.Name.String)
-			}
-			if pp4.Place.ID != pp.Place.ID {
-				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp4.Place.ID)
+				place.id = :place.id`, benDoe)
+			require.NoError(t, err)
+
+			for pp4, err := range AllRows[PlaceOwner](rows) {
+				require.NoError(t, err)
+				assert.NotNil(t, pp4.Owner, "Expected `Owner` to not be nil")
+				assert.Equal(t, "ben", pp4.Owner.FirstName)
+				assert.Equal(t, "doe", pp4.Owner.LastName)
+				assert.Equal(t, "the-house", pp4.Place.Name.String)
+				assert.Equal(t, benDoe.Place.ID, pp4.Place.ID)
 			}
 		}
 
@@ -805,106 +751,70 @@ func TestNamedQueryContext(t *testing.T) {
 			Owner *OwnerDetails `db:"owner"`
 		}
 
-		pp5 := &PlaceOwnerDetails{}
-		rows, err = db.NamedQueryContext(ctx, `
+		{
+			rows, err = db.NamedQueryContext(ctx, `
 			SELECT
-				place.id AS "place.id",
-				place.name AS "place.name",
-				placeperson.first_name "owner.first_name",
-				placeperson.last_name "owner.last_name",
-				placeperson.email "owner.email",
-				persondetails.email "owner.details.email",
-				persondetails.notes "owner.details.notes"
+				place.id,
+				place.name,
+				placeperson.first_name,
+				placeperson.last_name,
+				placeperson.email,
+				persondetails.email,
+				persondetails.notes
 			FROM place
 			LEFT JOIN placeperson ON placeperson.place_id = place.id
 			LEFT JOIN persondetails ON false
 			WHERE
-				place.id=:place.id`, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for rows.Next() {
-			err = rows.StructScan(pp5)
-			if err != nil {
-				t.Error(err)
-			}
-			if pp5.Owner == nil {
-				t.Error("Expected `Owner`, to not be nil")
-			}
-			if pp5.Owner.FirstName != "ben" {
-				t.Error("Expected first name of `ben`, got " + pp5.Owner.FirstName)
-			}
-			if pp5.Owner.LastName != "doe" {
-				t.Error("Expected first name of `doe`, got " + pp5.Owner.LastName)
-			}
-			if pp5.Place.Name.String != "the-house" {
-				t.Error("Expected place name of `the-house`, got " + pp5.Place.Name.String)
-			}
-			if pp5.Place.ID != pp.Place.ID {
-				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp5.Place.ID)
-			}
-			if pp5.Owner.Details != nil {
-				t.Error("Expected `Details` to be nil")
+				place.id = :place.id`, benDoe)
+			require.NoError(t, err)
+
+			for pp5, err := range AllRows[PlaceOwnerDetails](rows) {
+				require.NoError(t, err)
+				assert.NotNil(t, pp5.Owner, "Expected `Owner`, to not be nil")
+				assert.Equal(t, "ben", pp5.Owner.FirstName)
+				assert.Equal(t, "doe", pp5.Owner.LastName)
+				assert.Equal(t, benDoe.Email.String, *pp5.Owner.Email)
+				assert.Equal(t, "the-house", pp5.Place.Name.String)
+				assert.Equal(t, pp5.Place.ID, benDoe.Place.ID)
+				assert.Nil(t, pp5.Owner.Details)
 			}
 		}
 
-		details := Details{
-			Email: pp.Email.String,
-			Notes: "this is a test person",
-		}
+		{
+			details := Details{
+				Email: benDoe.Email.String,
+				Notes: "this is a test person",
+			}
 
-		q6 := `INSERT INTO persondetails (email, notes) VALUES (:email, :notes)`
-		_, err = db.NamedExecContext(ctx, q6, details)
-		if err != nil {
-			log.Fatal(err)
-		}
+			_, err = db.NamedExecContext(ctx, `INSERT INTO persondetails (email, notes) VALUES (:email, :notes)`, details)
+			require.NoError(t, err)
 
-		pp6 := &PlaceOwnerDetails{}
-		rows, err = db.NamedQueryContext(ctx, `
+			rows, err = db.NamedQueryContext(ctx, `
 			SELECT
-				place.id AS "place.id",
-				place.name AS "place.name",
-				placeperson.first_name "owner.first_name",
-				placeperson.last_name "owner.last_name",
-				placeperson.email "owner.email",
-				persondetails.email "owner.details.email",
-				persondetails.notes "owner.details.notes"
+				place.id,
+				place.name,
+				placeperson.first_name,
+				placeperson.last_name,
+				placeperson.email,
+				persondetails.email,
+				persondetails.notes
 			FROM place
 			LEFT JOIN placeperson ON placeperson.place_id = place.id
 			LEFT JOIN persondetails ON persondetails.email = placeperson.email
 			WHERE
-				place.id=:place.id`, pp)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for rows.Next() {
-			err = rows.StructScan(pp6)
-			if err != nil {
-				t.Error(err)
-			}
-			if pp6.Owner == nil {
-				t.Error("Expected `Owner` to not be nil")
-			}
-			if pp6.Owner.FirstName != "ben" {
-				t.Error("Expected first name of `ben`, got " + pp6.Owner.FirstName)
-			}
-			if pp6.Owner.LastName != "doe" {
-				t.Error("Expected first name of `doe`, got " + pp6.Owner.LastName)
-			}
-			if pp6.Place.Name.String != "the-house" {
-				t.Error("Expected place name of `the-house`, got " + pp6.Place.Name.String)
-			}
-			if pp6.Place.ID != pp.Place.ID {
-				t.Errorf("Expected place name of %v, got %v", pp.Place.ID, pp6.Place.ID)
-			}
-			if pp6.Owner.Details == nil {
-				t.Error("Expected `Details` to not be nil")
-			}
-			if pp6.Owner.Details.Email != details.Email {
-				t.Errorf("Expected details email of %v, got %v", details.Email, pp6.Owner.Details.Email)
-			}
-			if pp6.Owner.Details.Notes != details.Notes {
-				t.Errorf("Expected details notes of %v, got %v", details.Notes, pp6.Owner.Details.Notes)
+				place.id = :place.id`, benDoe)
+			require.NoError(t, err)
+
+			for pp6, err := range AllRows[PlaceOwnerDetails](rows) {
+				require.NoError(t, err)
+				assert.NotNil(t, pp6.Owner, "Expected `Owner`, to not be nil")
+				assert.Equal(t, "ben", pp6.Owner.FirstName)
+				assert.Equal(t, "doe", pp6.Owner.LastName)
+				assert.Equal(t, "the-house", pp6.Place.Name.String)
+				assert.Equal(t, pp6.Place.ID, pp6.Place.ID)
+				assert.NotNil(t, pp6.Owner.Details, "Expected `Details` to not be nil")
+				assert.Equal(t, details.Email, pp6.Owner.Details.Email)
+				assert.Equal(t, details.Notes, pp6.Owner.Details.Notes)
 			}
 		}
 	})


### PR DESCRIPTION
Merging code that fixes https://github.com/jmoiron/sqlx/issues/162

This is the upstream work from multiple authors in https://github.com/jmoiron/sqlx/pull/950 which makes for a much improved and intuitive experience when scanning joined tables.

There is the possibility of slight breakage with this change if client code depended on the result of the scan being non-nil for embedded structs, but pointer members is not typical usage and the likelihood of breakage is small enough to not be a serious problem.

This behavior matches expectations set by other scanning behavior where struct members are made pointers for possibly null values. Extending that behavior to struct members increases consistency.

Alternatively, we could have used omitempty tags to opt into the behavior, but this is different than other struct members that don't need a tag.